### PR TITLE
remove duplicates in 'receive' function

### DIFF
--- a/gateway/gateway.ino
+++ b/gateway/gateway.ino
@@ -75,11 +75,7 @@ void receive(const MyMessage &message) {
   if (message.type==V_STATUS) {
     CustomSensor sensor = CustomSensor::getSensorById(message.sensor, customSensors);
     const bool value = message.getBool();
-    // Store state in eeprom
-    saveState(sensor.id, value);
-    // Change relay state
-    digitalWrite(sensor.pin, value);
-    // Send ACK
-    send(sensor.message.set(value));
+    // Store state in eeprom and send message
+    setOutput(sensor.id, value);
   }
 }

--- a/gateway/gateway.ino
+++ b/gateway/gateway.ino
@@ -22,6 +22,7 @@
 #include "./Mapping/Mapping.hpp"
 #include "./Automation/Automation.hpp"
 
+// TODO: Replace duplication of 'saveState' and 'digitalWrite' with 'setOutput'
 void before() {
   for (const CustomSensor sensor : customSensors) {
     const uint8_t pin = sensor.pin;


### PR DESCRIPTION
Remove duplicates in `receive`:
```
    // Store state in eeprom
    saveState(sensor.id, value);
    // Change relay state
    digitalWrite(sensor.pin, value);
    // Send ACK
    send(sensor.message.set(value));
```
and replace with:
```
    // Store state in eeprom and send message
    setOutput(sensor.id, value);
```